### PR TITLE
HOTIFX: Boostrap JS Links

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -22,9 +22,9 @@
 						Fax: (207) 367-2585<br />
 						Email: <a href="mailto:clhaskell@clhaskellelectric.com">clhaskell@clhaskellelectric.com</a>
 					</p>
-					
-					<p>We are available Monday through Friday from 7:00 AM to 4:00 PM. <br /> <br />Feel free to 
-						contact us with any questions you may have. We will do our best to make sure 
+
+					<p>We are available Monday through Friday from 7:00 AM to 4:00 PM. <br /> <br />Feel free to
+						contact us with any questions you may have. We will do our best to make sure
 						you get the services you need as soon as possible.</p>
 					<p>Our mailing address is <strong>P.O. Box 43, Stonington, Maine 04681</strong></p>
 
@@ -59,6 +59,13 @@
 				<small> </small>
 			</div>
 		</footer>
+
+		<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+			integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+			crossorigin="anonymous"></script>
+		<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+			integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+			crossorigin="anonymous"></script>
 	</body>
 
 </html>

--- a/past-projects.html
+++ b/past-projects.html
@@ -34,15 +34,12 @@
         </div>
       </div>
     </footer>
-    <script src="services_files/jquery-3.js"
-      integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
-      crossorigin="anonymous"></script>
-    <script src="services_files/popper.js"
-      integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
-      crossorigin="anonymous"></script>
-    <script src="services_files/bootstrap.js"
-      integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
-      crossorigin="anonymous"></script>
+		<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+			integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+			crossorigin="anonymous"></script>
+		<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+			integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+			crossorigin="anonymous"></script>
     </div>
   </body>
 

--- a/services.html
+++ b/services.html
@@ -82,15 +82,12 @@
       </div>
     </footer>
 
-    <script src="services_files/jquery-3.js"
-      integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN"
-      crossorigin="anonymous"></script>
-    <script src="services_files/popper.js"
-      integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q"
-      crossorigin="anonymous"></script>
-    <script src="services_files/bootstrap.js"
-      integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl"
-      crossorigin="anonymous"></script>
+		<script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
+			integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+			crossorigin="anonymous"></script>
+		<script src="https://cdn.jsdelivr.net/npm/bootstrap@4.5.3/dist/js/bootstrap.bundle.min.js"
+			integrity="sha384-ho+j7jyWK8fNQe+A12Hb8AhRq26LrZ/JpcUGGOn+Y7RsweNrtN/tE3MoK7ZeZDyx"
+			crossorigin="anonymous"></script>
     </div>
   </body>
 


### PR DESCRIPTION
Links to the Boostrap JS CDNs were broken on contact page and outdated on services page. Update fixes menu dropdown on mobile